### PR TITLE
Pass the AWS account id to the Common Fate API

### DIFF
--- a/.changeset/good-trainers-help.md
+++ b/.changeset/good-trainers-help.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-commonfate-proxy-resource-rds": patch
+---
+
+Provide the current aws account id when registering the database resource with the Common Fate API. The account and region must match the Proxy integration.


### PR DESCRIPTION
The AWS account is now passed through the provider which validates that this database modules is deployed to the same account and region as the Proxy