### PR TITLE
allow rds_security_group_id to be empty

### DIFF
--- a/.changeset/lazy-fishes-cry.md
+++ b/.changeset/lazy-fishes-cry.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-commonfate-proxy-resource-rds": patch
+---
+
+Allow the rds_security_group_id to be empty when create_security_group_rule is false.

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,9 @@ variable "rds_security_group_id" {
   default     = ""
 
   validation {
-    condition     = var.create_security_group_rule == true && length(var.rds_security_group_id) == 0
+    # when create_security_group_rule is false, a rds_security_group_id is not required, it can either have a value or be empty
+    # when create_security_group_rule is true, rds_security_group_id must not be empty
+    condition     = var.create_security_group_rule == false || length(var.rds_security_group_id) > 0
     error_message = "rds_security_group_id must not be empty when create_security_group_rule is true."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "rds_security_group_id" {
   default     = ""
 
   validation {
-    condition     = var.create_security_group_rule == false || length(var.rds_security_group_id) > 0
+    condition     = var.create_security_group_rule == true && length(var.rds_security_group_id) == 0
     error_message = "rds_security_group_id must not be empty when create_security_group_rule is true."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,13 +25,16 @@ variable "app_url" {
   }
 }
 
-
 variable "rds_security_group_id" {
   description = "The security group attached with your RDS database."
   type        = string
+  default     = ""
+
+  validation {
+    condition     = var.create_security_group_rule == false || length(var.rds_security_group_id) > 0
+    error_message = "rds_security_group_id must not be empty when create_security_group_rule is true."
+  }
 }
-
-
 
 variable "rds_instance_identifier" {
   description = "The identifier of the rds instance."
@@ -63,6 +66,7 @@ variable "users" {
   }))
 
 }
+
 
 variable "create_security_group_rule" {
   description = "If 'true', will create a rule allowing ingress from the proxy to the database security group. The database security group is specified by the 'rds_security_group_id' variable."


### PR DESCRIPTION
When the create_security_group_rule variable is false, the rds_security_group_id does not need to be provided